### PR TITLE
Fix #7: disable of navigation rendering if Telescope is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `mad-web/nova-telescope-link` will be documented in this 
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## 2.0.2 - Under Development
+
+- added disabling of navigation link rendering if Telescope is disabled, preventing PHP error
+
 ## 2.0.1 - 2019-04-30
 
 - replaced html tag of navigation link from `a` to `h3` to make it compatible with different themes

--- a/src/TelescopeLink.php
+++ b/src/TelescopeLink.php
@@ -44,6 +44,10 @@ class TelescopeLink extends Tool
      */
     public function renderNavigation()
     {
+        if (! config('telescope.enabled')) {
+            return '';
+        }
+
         return view(self::VIEW_NAME);
     }
 


### PR DESCRIPTION
Fix #7 disabling of navigation link rendering if Telescope is disabled, preventing PHP error.