### PR TITLE
Remove parent construct call

### DIFF
--- a/src/TelescopeLink.php
+++ b/src/TelescopeLink.php
@@ -14,8 +14,6 @@ class TelescopeLink extends Tool
 
     public function __construct(?string $label = 'Telescope Debug', string $target = 'self')
     {
-        parent::__construct();
-
         $this->label = $label;
         $this->target = $target;
     }


### PR DESCRIPTION
This PR fixes #15.

I haven't tested this fix on older versions of Laravel Nova, so I'm not 100% sure it won't break anything. However, it does seem to be the fix to linked issue.